### PR TITLE
Update/requirements

### DIFF
--- a/polyunite/parsers.py
+++ b/polyunite/parsers.py
@@ -109,7 +109,21 @@ class Classification(collections.UserDict):
     @property
     def name(self) -> str:
         """'name' of the virus"""
-        return next(self.lastgroups('CVE', 'FAMILY'), self.source)
+        name = next(self.lastgroups('CVE', 'FAMILY'), '')
+        # for those really hard to parse lables
+        pattern = rf"""^({LABELS:x})?
+                        ({LANGS:x})?
+                        ({ARCHIVES:x})?
+                        ({MACROS:x})?
+                        ({OSES:x})?
+                        ({OBFUSCATIONS:x})?
+                        ({HEURISTICS:x})?
+                       $"""
+        regex = re.compile(pattern, re.VERBOSE)
+        match = regex.fullmatch(name)
+        if match:
+            return ''
+        return name
 
     @property
     def av_vendor(self) -> str:

--- a/polyunite/parsers.py
+++ b/polyunite/parsers.py
@@ -175,21 +175,9 @@ class DrWeb(Classification):
 
 
 class Ikarus(Classification):
-    pattern = rf"""^
-              (?:{HEURISTICS}\:?)?
-              (?:(?:\A|[.]|\b)(-?{LABELS}|{OBFUSCATIONS}|{PLATFORM}|Patched))*
-              (?:(?:\A|[.]|\b)
-                    (?P<NAME>
-                        (?P<FAMILY>BO|(?:[i0-9]?[A-Z][\w_-]{{2,}}))?
-                        (?P<VARIANT>
-                            [.](?:[0-9]+|[a-z]+|[A-Z]+|[A-F0-9]+) |
-                            (?i:[.#@!]\L<suffixes>)
-                         ){{,2}}
-                    )
-                    (?:[.](?:{OSES}|{LANGS}|{MACROS}|{HEURISTICS}))?
-                )?
-
-    $"""
+    pattern = rf"""^(not-a-virus:)? ({OBFUSCATIONS}\.)?
+                    (({LABELS}(-\w+)?)\.)? (({PLATFORM})\.)? (?P<FAMILY>.*)?
+                    $"""
 
 
 class Jiangmin(Classification):

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,9 @@ from setuptools import setup, find_packages
 with open('README.rst') as readme_file:
     readme = readme_file.read()
 
-requirements = [ ]
+requirements = [ 'regex' ]
 
-setup_requirements = ['pytest-runner', 'regex']
+setup_requirements = ['pytest-runner']
 
 test_requirements = ['pytest', ]
 


### PR DESCRIPTION
* Changed `regex` lib to `requirements` for auto-installing with `python setup.py install`, otherwise it will not include it and will fail as 
```    import regex as re
ModuleNotFoundError: No module named 'regex'
```
https://setuptools.readthedocs.io/en/latest/setuptools.html